### PR TITLE
Fix/ne 43 error lvls

### DIFF
--- a/dac161s997.h
+++ b/dac161s997.h
@@ -22,10 +22,11 @@
 #define DAC161S997_H_
 
 /* Defines ********************************************************************/
-#define DAC161S997_MIN_NA   ((uint32_t)4000000)     /**< Min valid nA */
-#define DAC161S997_MAX_NA   ((uint32_t)20000000)    /**< Max valid nA */
-#define DAC161S997_LO_ALARM_NA ((uint32_t)2000000)  /**< Lo error value in nA */
-#define DAC161S997_HI_ALARM_NA ((uint32_t)22000000) /**< Hi error value in nA */
+#define DAC161S997_ALARM_LOW_FAIL_ERR   0x0100
+#define DAC161S997_ALARM_LOW_SAT_ERR    0x0200
+#define DAC161S997_ALARM_UNINIT_ERR    0x0400
+#define DAC161S997_ALARM_HI_SAT_ERR     0x0800
+#define DAC161S997_ALARM_HI_FAIL_ERR    0x1000
 
 /**
  * @defgroup I420_STATUS_MASK
@@ -41,8 +42,11 @@
 
 /* Typedefs *******************************************************************/
 typedef enum {
-    DAC161S997_ALARM_LOW,   /**< Set output to undercurrent */
-    DAC161S997_ALARM_HIGH,  /**< Set output to overcurrent */
+    DAC161S997_ALARM_LOW_FAIL   = DAC161S997_ALARM_LOW_FAIL_ERR ,
+    DAC161S997_ALARM_LOW_SAT    = DAC161S997_ALARM_LOW_SAT_ERR ,
+    DAC161S997_ALARM_UNINIT     = DAC161S997_ALARM_UNINIT_ERR ,
+    DAC161S997_ALARM_HIGH_SAT   = DAC161S997_ALARM_HI_SAT_ERR,
+    DAC161S997_ALARM_HIGH_FAIL  = DAC161S997_ALARM_HI_FAIL_ERR ,
 } DAC161S997_ALARM_t;       /**< DAC161S997 alarm types */
 
 /**

--- a/dac161s997.h
+++ b/dac161s997.h
@@ -22,11 +22,14 @@
 #define DAC161S997_H_
 
 /* Defines ********************************************************************/
-#define DAC161S997_ALARM_LOW_FAIL_ERR   0x0100
-#define DAC161S997_ALARM_LOW_SAT_ERR    0x0200
-#define DAC161S997_ALARM_UNINIT_ERR    0x0400
-#define DAC161S997_ALARM_HI_SAT_ERR     0x0800
-#define DAC161S997_ALARM_HI_FAIL_ERR    0x1000
+#define DAC161S997_MIN_NA   ((uint32_t)4000000)     /**< Min valid nA */
+#define DAC161S997_MAX_NA   ((uint32_t)20000000)    /**< Max valid nA */
+
+#define DAC161S997_ALARM_LOW_FAIL_ERR   0x0100 /**< Error flag for low device failure */
+#define DAC161S997_ALARM_LOW_SAT_ERR    0x0200 /**< Error flag for value set to lower bound saturation */
+#define DAC161S997_ALARM_UNINIT_ERR     0x0400 /**< Error flag for device uninitialized */
+#define DAC161S997_ALARM_HI_SAT_ERR     0x0800 /**< Error flag for value set to upper bound saturation */
+#define DAC161S997_ALARM_HI_FAIL_ERR    0x1000 /**< Error flag for high device failure */
 
 /**
  * @defgroup I420_STATUS_MASK
@@ -42,11 +45,11 @@
 
 /* Typedefs *******************************************************************/
 typedef enum {
-    DAC161S997_ALARM_LOW_FAIL   = DAC161S997_ALARM_LOW_FAIL_ERR ,
-    DAC161S997_ALARM_LOW_SAT    = DAC161S997_ALARM_LOW_SAT_ERR ,
-    DAC161S997_ALARM_UNINIT     = DAC161S997_ALARM_UNINIT_ERR ,
-    DAC161S997_ALARM_HIGH_SAT   = DAC161S997_ALARM_HI_SAT_ERR,
-    DAC161S997_ALARM_HIGH_FAIL  = DAC161S997_ALARM_HI_FAIL_ERR ,
+    DAC161S997_ALARM_LOW_FAIL   = DAC161S997_ALARM_LOW_FAIL_ERR,    /**< Alarm for low device failure */
+    DAC161S997_ALARM_LOW_SAT    = DAC161S997_ALARM_LOW_SAT_ERR,     /**< Alarm for value set to lower bound saturation */
+    DAC161S997_ALARM_UNINIT     = DAC161S997_ALARM_UNINIT_ERR,      /**< Alarm for device uninitialized */
+    DAC161S997_ALARM_HIGH_SAT   = DAC161S997_ALARM_HI_SAT_ERR,      /**< Alarm for value set to upper bound saturation */
+    DAC161S997_ALARM_HIGH_FAIL  = DAC161S997_ALARM_HI_FAIL_ERR,     /**< Alarm for high device failure */
 } DAC161S997_ALARM_t;       /**< DAC161S997 alarm types */
 
 /**

--- a/src/dac161s997.c
+++ b/src/dac161s997.c
@@ -108,6 +108,7 @@ error_t dac161s997_set_alarm(dac161s997_dev_t *dev, DAC161S997_ALARM_t alarm)
     else if (alarm == DAC161S997_ALARM_HIGH_FAIL) {
         return dac161s997_write_reg(dev, DAC161S997_DACCODE_REG,
                                     _NA_TO_DAC_TICKS(DAC161S997_FAIL_HI_ALARM_NA));
+    }
     return -EINVAL;
 }
 

--- a/src/dac161s997.c
+++ b/src/dac161s997.c
@@ -20,10 +20,6 @@
 #define _NOT_PROTECTED                  0
 #define _PROTECTED                      1
 
-/* Minimum and maximum valid output current in nA *****************************/
-#define DAC161S997_MIN_NA   ((uint32_t)4000000)     /**< Min valid nA */
-#define DAC161S997_MAX_NA   ((uint32_t)20000000)    /**< Max valid nA */
-
 /* Error levels as per NAMUR NE43 *********************************************/
 #define DAC161S997_UNINIT_ALARM_NA  ((uint32_t)3300000)  /**< Uninitialized value in nA */
 #define DAC161S997_FAIL_LO_ALARM_NA ((uint32_t)3600000)  /**< Lo error value in nA */

--- a/src/dac161s997.c
+++ b/src/dac161s997.c
@@ -20,6 +20,17 @@
 #define _NOT_PROTECTED                  0
 #define _PROTECTED                      1
 
+/* Minimum and maximum valid output current in nA *****************************/
+#define DAC161S997_MIN_NA   ((uint32_t)4000000)     /**< Min valid nA */
+#define DAC161S997_MAX_NA   ((uint32_t)20000000)    /**< Max valid nA */
+
+/* Error levels as per NAMUR NE43 *********************************************/
+#define DAC161S997_UNINIT_ALARM_NA  ((uint32_t)3300000)  /**< Uninitialized value in nA */
+#define DAC161S997_FAIL_LO_ALARM_NA ((uint32_t)3600000)  /**< Lo error value in nA */
+#define DAC161S997_SAT_LO_ALARM_NA  ((uint32_t)3800000)  /**< Lo saturation value in nA */
+#define DAC161S997_SAT_HI_ALARM_NA  ((uint32_t)20500000) /**< Hi saturation value in nA */
+#define DAC161S997_FAIL_HI_ALARM_NA ((uint32_t)21000000) /**< Hi error value in nA */
+
 #define _ERR_CONFIG_SPI_TIMOUT_400MS    (7 << 1)
 
 /******************************************************************************/
@@ -55,19 +66,19 @@ error_t dac161s997_init(dac161s997_dev_t *dev)
 
     err =
         dac161s997_write_reg(dev, DAC161S997_ERR_LOW_REG, _NA_TO_DAC_TICKS(
-                                 DAC161S997_LO_ALARM_NA));
+                                 DAC161S997_FAIL_LO_ALARM_NA));
     if (err) {
         return err;
     }
 
     err =
         dac161s997_write_reg(dev, DAC161S997_ERR_HIGH_REG, _NA_TO_DAC_TICKS(
-                                 DAC161S997_HI_ALARM_NA));
+                                 DAC161S997_FAIL_HI_ALARM_NA));
     if (err) {
         return err;
     }
 
-    err = dac161s997_set_alarm(dev, DAC161S997_ALARM_LOW);
+    err = dac161s997_set_alarm(dev, DAC161S997_ALARM_LOW_FAIL);
     return err;
 }
 
@@ -82,14 +93,21 @@ error_t dac161s997_set_output(dac161s997_dev_t *dev, int32_t n_amps)
 
 error_t dac161s997_set_alarm(dac161s997_dev_t *dev, DAC161S997_ALARM_t alarm)
 {
-    if (alarm == DAC161S997_ALARM_LOW) {
+    if (alarm == DAC161S997_ALARM_LOW_FAIL) {
         return dac161s997_write_reg(dev, DAC161S997_DACCODE_REG,
-                                    _NA_TO_DAC_TICKS(DAC161S997_LO_ALARM_NA));
+                                    _NA_TO_DAC_TICKS(DAC161S997_FAIL_LO_ALARM_NA));
     }
-    else if (alarm == DAC161S997_ALARM_HIGH) {
+    else if (alarm == DAC161S997_ALARM_LOW_SAT) {
         return dac161s997_write_reg(dev, DAC161S997_DACCODE_REG,
-                                    _NA_TO_DAC_TICKS(DAC161S997_HI_ALARM_NA));
+                                    _NA_TO_DAC_TICKS(DAC161S997_SAT_LO_ALARM_NA));
     }
+    else if (alarm == DAC161S997_ALARM_HIGH_SAT) {
+        return dac161s997_write_reg(dev, DAC161S997_DACCODE_REG,
+                                    _NA_TO_DAC_TICKS(DAC161S997_SAT_HI_ALARM_NA));
+    }
+    else if (alarm == DAC161S997_ALARM_HIGH_FAIL) {
+        return dac161s997_write_reg(dev, DAC161S997_DACCODE_REG,
+                                    _NA_TO_DAC_TICKS(DAC161S997_FAIL_HI_ALARM_NA));
     return -EINVAL;
 }
 


### PR DESCRIPTION
Implementation of standardized error levels as per NAMUR NE-43 as discussed in feature request.  Also moved max/min current defines into .c file.

Fixes #1